### PR TITLE
Fix requestUrl logic

### DIFF
--- a/index.php
+++ b/index.php
@@ -13,7 +13,7 @@ require_once('vendor/autoload.php');
 const LIGHTSPEED_JWKS_ENDPOINT = 'https://cloud.lightspeedapp.com/.well-known/jwks';
 
 // Rebuild the request URL
-$requestUrl = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on')  ? 'https://' : 'http://'
+$requestUrl = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on'  ? 'https://' : 'http://')
     . $_SERVER['HTTP_HOST']
     // ensure the path starts with a slash
     . '/' . ltrim($_SERVER['REQUEST_URI'], '/');


### PR DESCRIPTION
On https, the ternary operator short-circuits and $requestUrl is set to 'https://'. With the parenthesis in the right place, this code works for http AND https.