### PR TITLE
SEC-8875 Change code scanning to use psalm directly

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -2,14 +2,27 @@ name: Static Code Security Analysis (psalm)
 
 on:
   push:
-    branches: [ master, main ]
+    branches: [ master, main, demo ]
   pull_request:
-    branches: [ master, main ]
+    branches: [ master, main, demo ]
 
 jobs:
   analyze:
+    Name: Code Scanning (Psalm)
     permissions:
       actions: read
       contents: read
       security-events: write
-    uses: lightspeed-security/code-scanning-workflows/.github/workflows/psalm-php.yml@main
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Psalm
+        uses: docker://ghcr.io/psalm/psalm-github-actions:6.10.3
+        with:
+          security_analysis: true
+          report_file: results.sarif
+      - name: Upload Security Analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   analyze:
-    Name: Code Scanning (Psalm)
+    name: Code Scanning (Psalm)
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   analyze:
+    runs-on: ubuntu-latest
     name: Code Scanning (Psalm)
     permissions:
       actions: read


### PR DESCRIPTION
![sarlah-sarlahthecat](https://github.com/user-attachments/assets/0b7f0609-227e-4c41-9d32-768065bb146a)

https://lightspeedhq.atlassian.net/browse/SEC-8875

Change code scanning to use Psalm directly instead of using a reusable code scanning workflow. Our code scanning workflows are stored in a private repo and can't be used by public repositories.